### PR TITLE
feat: jaw-dropping multi-step audit wizard (owned, on-brand)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import ProductShowcaseSection from "@/sections/ProductShowcaseSection";
 import OpenSourceSection from "@/sections/OpenSourceSection";
 import AboutSection from "@/sections/AboutSection";
 import FAQSection from "@/sections/FAQSection";
-import EnterpriseSection from "@/sections/EnterpriseSection";
+import AuditWizard from "@/sections/AuditWizard";
 import CTASection from "@/sections/CTASection";
 import FooterSection from "@/sections/FooterSection";
 import JsonLd from "@/components/seo/JsonLd";
@@ -28,7 +28,7 @@ export default function Home() {
         <OpenSourceSection />
         <AboutSection />
         <FAQSection />
-        <EnterpriseSection />
+        <AuditWizard />
         <CTASection />
         <FooterSection />
       </main>

--- a/src/data/auditWizard.ts
+++ b/src/data/auditWizard.ts
@@ -1,0 +1,123 @@
+export type WizardFieldType = "select" | "text" | "email" | "textarea";
+
+export interface WizardOption {
+  value: string;
+  label: string;
+  hint?: string;
+  score?: number; // contribution to the internal lead-fit score
+}
+
+export interface WizardStep {
+  id: string;
+  type: WizardFieldType;
+  question: string;
+  subtext?: string;
+  placeholder?: string;
+  optional?: boolean;
+  options?: WizardOption[];
+}
+
+/**
+ * The audit intake wizard — one question per screen. Select steps auto-advance;
+ * text/email/textarea steps advance on Enter or the Continue button. Answers are
+ * composed into the Contact `Message` field on submit (see composeMessage) so the
+ * existing Airtable schema needs no new columns.
+ */
+export const wizardSteps: WizardStep[] = [
+  {
+    id: "focus",
+    type: "select",
+    question: "Where's the most time leaking right now?",
+    subtext: "Pick the area that eats the most hours each week.",
+    options: [
+      { value: "Lead follow-up & sales", label: "Lead follow-up & sales", hint: "Chasing leads, quotes, pipeline", score: 20 },
+      { value: "CRM & data entry", label: "CRM & data entry", hint: "Updating records, copy-paste work", score: 20 },
+      { value: "Customer support", label: "Customer support", hint: "Repetitive questions, busy inboxes", score: 18 },
+      { value: "Reporting & admin", label: "Reporting & admin", hint: "Weekly reports, invoicing", score: 18 },
+      { value: "Scheduling & operations", label: "Scheduling & operations", hint: "Booking, dispatch, coordination", score: 16 },
+      { value: "Something else", label: "Something else", hint: "Tell us in the next step", score: 10 },
+    ],
+  },
+  {
+    id: "detail",
+    type: "textarea",
+    question: "Walk us through it.",
+    subtext:
+      "What does that work look like today? The messier the better — that's exactly where an AI worker earns its keep.",
+    placeholder:
+      "e.g. Every morning I copy new leads from email into the CRM, then send the same 3 follow-ups by hand…",
+  },
+  {
+    id: "team",
+    type: "select",
+    question: "How big is your team?",
+    options: [
+      { value: "Just me", label: "Just me", score: 10 },
+      { value: "2–10", label: "2–10 people", score: 20 },
+      { value: "11–50", label: "11–50 people", score: 20 },
+      { value: "50+", label: "50+ people", score: 14 },
+    ],
+  },
+  {
+    id: "timeline",
+    type: "select",
+    question: "When do you want this handled?",
+    options: [
+      { value: "ASAP", label: "Yesterday — it's costing me now", score: 25 },
+      { value: "This quarter", label: "This quarter", score: 18 },
+      { value: "Exploring", label: "Just exploring for now", score: 8 },
+    ],
+  },
+  {
+    id: "tried",
+    type: "select",
+    question: "Tried to automate any of it before?",
+    subtext: "No wrong answer — it just helps us pitch you the right next step.",
+    optional: true,
+    options: [
+      { value: "Not yet", label: "Not yet", score: 8 },
+      { value: "DIY tools", label: "DIY tools (Zapier, Make, etc.)", score: 12 },
+      { value: "Hired help", label: "Hired a freelancer or agency", score: 14 },
+      { value: "Other", label: "Other", score: 8 },
+    ],
+  },
+  {
+    id: "name",
+    type: "text",
+    question: "Who are we sending the audit to?",
+    placeholder: "Jane Smith",
+  },
+  {
+    id: "email",
+    type: "email",
+    question: "Where should the audit land?",
+    subtext:
+      "We'll email your 1–3 highest-impact opportunities within one business day. No call required, no spam.",
+    placeholder: "jane@company.com",
+  },
+];
+
+export function leadScore(answers: Record<string, string>): number {
+  let score = 0;
+  for (const step of wizardSteps) {
+    if (!step.options) continue;
+    const opt = step.options.find((o) => o.value === answers[step.id]);
+    if (opt?.score) score += opt.score;
+  }
+  return Math.min(100, score);
+}
+
+/** Fold every wizard answer + the lead-fit score into a single Message string. */
+export function composeMessage(answers: Record<string, string>): string {
+  return [
+    `Primary time-sink: ${answers.focus || "—"}`,
+    ``,
+    `Details: ${answers.detail || "—"}`,
+    ``,
+    `Team size: ${answers.team || "—"}`,
+    `Timeline: ${answers.timeline || "—"}`,
+    `Tried before: ${answers.tried || "—"}`,
+    ``,
+    `Lead-fit score: ${leadScore(answers)}/100`,
+  ].join("\n");
+}

--- a/src/sections/AuditWizard.tsx
+++ b/src/sections/AuditWizard.tsx
@@ -1,0 +1,375 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { apiClient } from "@/utils/client";
+import { Contact } from "@/types";
+import {
+  wizardSteps,
+  composeMessage,
+  type WizardStep,
+} from "@/data/auditWizard";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const stepVariants = {
+  enter: (dir: number) => ({ x: dir > 0 ? 56 : -56, opacity: 0 }),
+  center: { x: 0, opacity: 1 },
+  exit: (dir: number) => ({ x: dir > 0 ? -56 : 56, opacity: 0 }),
+};
+
+function isValid(step: WizardStep, value: string): boolean {
+  if (step.optional) return true;
+  const v = (value || "").trim();
+  if (step.type === "email") return EMAIL_RE.test(v);
+  return v.length > 0;
+}
+
+export default function AuditWizard() {
+  const [index, setIndex] = useState(0);
+  const [direction, setDirection] = useState(1);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<Status>("idle");
+  const [website, setWebsite] = useState(""); // honeypot
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+
+  const step = wizardSteps[index];
+  const value = answers[step.id] ?? "";
+  const isLast = index === wizardSteps.length - 1;
+  const canAdvance = isValid(step, value);
+  const progress = ((index + 1) / wizardSteps.length) * 100;
+  const submitting = status === "loading";
+
+  // Auto-focus text inputs as each step enters.
+  useEffect(() => {
+    if (step.type !== "select") {
+      const t = setTimeout(() => inputRef.current?.focus(), 60);
+      return () => clearTimeout(t);
+    }
+  }, [index, step.type]);
+
+  const setAnswer = (id: string, val: string) =>
+    setAnswers((prev) => ({ ...prev, [id]: val }));
+
+  const goNext = () => {
+    if (isLast) {
+      submit();
+      return;
+    }
+    setDirection(1);
+    setIndex((i) => Math.min(i + 1, wizardSteps.length - 1));
+  };
+
+  const goBack = () => {
+    if (index === 0) return;
+    setDirection(-1);
+    setIndex((i) => Math.max(i - 1, 0));
+  };
+
+  const pickOption = (val: string) => {
+    setAnswer(step.id, val);
+    // Brief highlight, then advance — feels responsive without being jarring.
+    setDirection(1);
+    setTimeout(() => {
+      if (index === wizardSteps.length - 1) submit({ ...answers, [step.id]: val });
+      else setIndex((i) => Math.min(i + 1, wizardSteps.length - 1));
+    }, 240);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && step.type !== "textarea") {
+      e.preventDefault();
+      if (canAdvance) goNext();
+    }
+  };
+
+  async function submit(finalAnswers?: Record<string, string>) {
+    const data = finalAnswers ?? answers;
+
+    // Honeypot — bots fill the hidden field. Fake success, never hit the API.
+    if (website.trim()) {
+      setStatus("success");
+      return;
+    }
+
+    setStatus("loading");
+    const payload: Contact = {
+      Name: data.name || "",
+      Email: data.email || "",
+      Phone: "",
+      Message: composeMessage(data),
+      Referrer: "audit-wizard",
+    };
+
+    try {
+      const res = await apiClient.contactFormSubmit(payload);
+      setStatus(res.ok ? "success" : "error");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <section
+      id="audit"
+      className="relative scroll-mt-20 overflow-hidden bg-gradient-to-b from-background to-green-500/5 px-4 py-24"
+    >
+      {/* Ambient glow + grid */}
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,#80808014_1px,transparent_1px),linear-gradient(to_bottom,#80808014_1px,transparent_1px)] bg-[size:32px_32px] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_40%,#000_60%,transparent_100%)]" />
+      <div className="pointer-events-none absolute left-1/2 top-1/3 h-[420px] w-[620px] -translate-x-1/2 rounded-full bg-green-500/10 blur-[120px]" />
+
+      <div className="relative mx-auto max-w-2xl">
+        {/* Eyebrow */}
+        <div className="mb-8 text-center">
+          <p className="mb-3 font-montserrat text-sm font-medium uppercase tracking-widest text-muted-foreground">
+            Free AI Workflow Audit
+          </p>
+          <h2 className="font-montserrat text-3xl font-bold text-foreground md:text-4xl">
+            Get your{" "}
+            <span className="font-space text-green-500 drop-shadow-[0_0_15px_rgba(34,197,94,0.55)]">
+              free audit
+            </span>{" "}
+            in 60 seconds
+          </h2>
+        </div>
+
+        <div className="rounded-3xl border border-green-500/20 bg-card/80 p-6 shadow-2xl backdrop-blur-sm md:p-10">
+          <AnimatePresence mode="wait">
+            {status === "success" ? (
+              <SuccessScreen key="success" email={answers.email} />
+            ) : (
+              <motion.div
+                key="wizard"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                {/* Progress */}
+                <div className="mb-8">
+                  <div className="mb-2 flex items-center justify-between font-montserrat text-xs text-muted-foreground">
+                    <span>
+                      Step {index + 1} of {wizardSteps.length}
+                    </span>
+                    <span>{Math.round(progress)}%</span>
+                  </div>
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
+                    <motion.div
+                      className="h-full rounded-full bg-green-500"
+                      animate={{ width: `${progress}%` }}
+                      transition={{ type: "spring", stiffness: 140, damping: 22 }}
+                    />
+                  </div>
+                </div>
+
+                {/* Step */}
+                <div className="min-h-[320px]">
+                  <AnimatePresence mode="wait" custom={direction}>
+                    <motion.div
+                      key={step.id}
+                      custom={direction}
+                      variants={stepVariants}
+                      initial="enter"
+                      animate="center"
+                      exit="exit"
+                      transition={{ type: "spring", stiffness: 260, damping: 30 }}
+                      onKeyDown={onKeyDown}
+                    >
+                      <h3 className="font-montserrat text-2xl font-bold text-foreground md:text-3xl">
+                        {step.question}
+                      </h3>
+                      {step.subtext && (
+                        <p className="mt-3 font-montserrat text-base text-muted-foreground">
+                          {step.subtext}
+                        </p>
+                      )}
+
+                      <div className="mt-8">
+                        {step.type === "select" && step.options && (
+                          <div className="grid gap-3">
+                            {step.options.map((opt) => {
+                              const selected = value === opt.value;
+                              return (
+                                <button
+                                  key={opt.value}
+                                  type="button"
+                                  onClick={() => pickOption(opt.value)}
+                                  className={`group flex items-center justify-between gap-4 rounded-2xl border p-4 text-left transition-all duration-200 ${
+                                    selected
+                                      ? "border-green-500 bg-green-500/10"
+                                      : "border-border bg-background hover:border-green-500/50 hover:bg-green-500/5"
+                                  }`}
+                                >
+                                  <span>
+                                    <span className="block font-montserrat font-semibold text-foreground">
+                                      {opt.label}
+                                    </span>
+                                    {opt.hint && (
+                                      <span className="mt-0.5 block font-montserrat text-sm text-muted-foreground">
+                                        {opt.hint}
+                                      </span>
+                                    )}
+                                  </span>
+                                  <span
+                                    className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border transition-colors ${
+                                      selected
+                                        ? "border-green-500 bg-green-500 text-black"
+                                        : "border-border text-transparent group-hover:border-green-500/50"
+                                    }`}
+                                  >
+                                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                                    </svg>
+                                  </span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {step.type === "textarea" && (
+                          <textarea
+                            ref={(el) => {
+                              inputRef.current = el;
+                            }}
+                            rows={4}
+                            value={value}
+                            placeholder={step.placeholder}
+                            onChange={(e) => setAnswer(step.id, e.target.value)}
+                            className="w-full resize-none rounded-2xl border border-border bg-background px-5 py-4 font-montserrat text-base text-foreground transition-colors focus:border-green-500 focus:outline-none"
+                          />
+                        )}
+
+                        {(step.type === "text" || step.type === "email") && (
+                          <input
+                            ref={(el) => {
+                              inputRef.current = el;
+                            }}
+                            type={step.type === "email" ? "email" : "text"}
+                            value={value}
+                            placeholder={step.placeholder}
+                            onChange={(e) => setAnswer(step.id, e.target.value)}
+                            className="w-full rounded-2xl border border-border bg-background px-5 py-4 font-montserrat text-lg text-foreground transition-colors focus:border-green-500 focus:outline-none"
+                          />
+                        )}
+                      </div>
+                    </motion.div>
+                  </AnimatePresence>
+                </div>
+
+                {/* Honeypot */}
+                <div aria-hidden="true" style={{ position: "absolute", left: "-9999px", opacity: 0 }}>
+                  <label htmlFor="wizard-website">Website</label>
+                  <input
+                    id="wizard-website"
+                    type="text"
+                    tabIndex={-1}
+                    autoComplete="off"
+                    value={website}
+                    onChange={(e) => setWebsite(e.target.value)}
+                  />
+                </div>
+
+                {status === "error" && (
+                  <p role="alert" className="mt-6 font-montserrat text-sm text-red-400">
+                    Something went wrong. Please try again, or email us at{" "}
+                    <a href="mailto:hello@mifune.dev" className="font-semibold underline hover:text-red-300">
+                      hello@mifune.dev
+                    </a>
+                    .
+                  </p>
+                )}
+
+                {/* Controls — select steps auto-advance, so hide Continue there */}
+                <div className="mt-8 flex items-center justify-between gap-4">
+                  <button
+                    type="button"
+                    onClick={goBack}
+                    disabled={index === 0}
+                    className="font-montserrat text-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-0"
+                  >
+                    ← Back
+                  </button>
+
+                  {step.type !== "select" && (
+                    <button
+                      type="button"
+                      onClick={goNext}
+                      disabled={!canAdvance || submitting}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-green-500 px-7 py-3 font-montserrat text-base font-medium text-black shadow-lg transition-all duration-200 hover:bg-green-400 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {submitting ? (
+                        <>
+                          <span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-black border-t-transparent" />
+                          Sending…
+                        </>
+                      ) : isLast ? (
+                        "Get My Free Audit"
+                      ) : (
+                        "Continue"
+                      )}
+                    </button>
+                  )}
+                </div>
+
+                {step.optional && step.type === "select" && (
+                  <button
+                    type="button"
+                    onClick={goNext}
+                    className="mt-4 w-full text-center font-montserrat text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    Skip this one
+                  </button>
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        <p className="mt-6 text-center font-montserrat text-xs text-muted-foreground">
+          No spam, ever. We reply within one business day — no call required to start.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function SuccessScreen({ email }: { email?: string }) {
+  return (
+    <motion.div
+      key="success-inner"
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      className="flex flex-col items-center py-10 text-center"
+      role="alert"
+    >
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ type: "spring", stiffness: 200, damping: 14, delay: 0.1 }}
+        className="flex h-20 w-20 items-center justify-center rounded-full border border-green-500/30 bg-green-500/10"
+      >
+        <svg className="h-10 w-10 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <motion.path
+            initial={{ pathLength: 0 }}
+            animate={{ pathLength: 1 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.5}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+      </motion.div>
+      <h3 className="mt-6 font-montserrat text-2xl font-bold text-foreground">
+        You&apos;re in. Audit incoming.
+      </h3>
+      <p className="mt-3 max-w-md font-montserrat text-muted-foreground">
+        We&apos;ll email your 1–3 highest-impact AI opportunities to{" "}
+        <span className="font-semibold text-foreground">{email || "your inbox"}</span>{" "}
+        within one business day. If it&apos;s not there, check your spam folder.
+      </p>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Why

The single-step audit form worked but couldn't both (a) qualify leads richly and (b) stay low-friction. A multi-step, one-question-at-a-time **wizard** flips that: each screen feels light, so we can ask more qualifying questions *and* lift completion — feeding the **email-first funnel** (form → value-first feedback in 1 business day → call only if it's a fit) with better data.

Built to the **"Jaw-Dropping Experience"** bar.

## What it is

A native, Typeform-style wizard at `#audit` (every existing CTA still lands here):

- **7 steps** — time-sink area (tappable cards) → open detail → team size → timeline → prior attempts (skippable) → name → email
- **Tappable option cards that auto-advance**; text/email/textarea advance on **Enter** or **Continue**; **Back** nav; **auto-focus** each step; animated **progress bar**
- **Springy directional slide transitions** (framer-motion `AnimatePresence`) and a **celebratory animated-checkmark success screen** that echoes the email
- A computed **lead-fit score** + every answer folded into the Contact `Message` field (`composeMessage`) — so your **existing Airtable schema needs zero new columns**
- Carries the form hardening: client-side **honeypot**, **try/catch** submit, `role="alert"` states, **mailto** on error

## "Better than Typeform"

- **Owned** — no third-party embed/script, no per-response limits, data goes straight to your Airtable. Matches "you own everything / no lock-in."
- **On-brand** — your dark/green design system, fonts, motion (Typeform is a rented off-brand iframe).
- **Fast & SEO-safe** — no heavy external script; preserves the structured-data/perf work.
- **A qualification engine** — branching-ready + lead scoring pre-prioritizes your inbox, not just a prettier form.

## Verify

- `npm run build` ✅ green; wizard renders at `#audit` with step 1 + progress.
- **Reviewer:** open the Netlify preview, click through all 7 steps (cards auto-advance, Enter advances text steps, Back works), submit, and confirm the success screen echoes the email. Then check the Airtable row's **Message** field holds the formatted Q&A + lead-fit score.

## Notes / your call

- **Stacked on PR #44** (SEO + social proof + CTA + form hardening) for a clean, conflict-free diff. **Merge #44 first**, then this retargets to `development`.
- `EnterpriseSection.tsx` is retained but no longer mounted — easy revert if you want the single-step form back. Say the word and I'll delete it.
- The extra wizard answers ride inside `Message` to avoid Airtable schema changes. If you'd rather have **dedicated Airtable columns** (Team size, Timeline, Lead score) for filtering/sorting, add those columns and I'll send them as structured fields.
- Phone is dropped from the flow (email-first); easy to add an opt-in "ok to call?" step if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
