### PR TITLE
feat: auto-latest YouTube "Watch & Learn" social proof

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -47,6 +47,10 @@ const withPWA = withPWAInit({
           protocol: "https",
           hostname: "secure.meetupstatic.com",
         },
+        {
+          protocol: "https",
+          hostname: "i.ytimg.com",
+        },
       ],
     },
     async redirects() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import PainSection from "@/sections/PainSection";
 import PricingSection from "@/sections/PricingSection";
 import ProductShowcaseSection from "@/sections/ProductShowcaseSection";
 import OpenSourceSection from "@/sections/OpenSourceSection";
+import WatchSection from "@/sections/WatchSection";
 import AboutSection from "@/sections/AboutSection";
 import FAQSection from "@/sections/FAQSection";
 import AuditWizard from "@/sections/AuditWizard";
@@ -26,6 +27,7 @@ export default function Home() {
         <PricingSection />
         <ProductShowcaseSection />
         <OpenSourceSection />
+        <WatchSection />
         <AboutSection />
         <FAQSection />
         <AuditWizard />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import ProductShowcaseSection from "@/sections/ProductShowcaseSection";
 import OpenSourceSection from "@/sections/OpenSourceSection";
 import AboutSection from "@/sections/AboutSection";
 import FAQSection from "@/sections/FAQSection";
-import EnterpriseSection from "@/sections/EnterpriseSection";
+import AuditWizard from "@/sections/AuditWizard";
 import CTASection from "@/sections/CTASection";
 import FooterSection from "@/sections/FooterSection";
 import JsonLd from "@/components/seo/JsonLd";
@@ -28,7 +28,7 @@ export default function Home() {
         <OpenSourceSection />
         <AboutSection />
         <FAQSection />
-        <EnterpriseSection />
+        <AuditWizard />
         <CTASection />
         <FooterSection />
       </main>

--- a/src/data/auditWizard.ts
+++ b/src/data/auditWizard.ts
@@ -1,0 +1,123 @@
+export type WizardFieldType = "select" | "text" | "email" | "textarea";
+
+export interface WizardOption {
+  value: string;
+  label: string;
+  hint?: string;
+  score?: number; // contribution to the internal lead-fit score
+}
+
+export interface WizardStep {
+  id: string;
+  type: WizardFieldType;
+  question: string;
+  subtext?: string;
+  placeholder?: string;
+  optional?: boolean;
+  options?: WizardOption[];
+}
+
+/**
+ * The audit intake wizard — one question per screen. Select steps auto-advance;
+ * text/email/textarea steps advance on Enter or the Continue button. Answers are
+ * composed into the Contact `Message` field on submit (see composeMessage) so the
+ * existing Airtable schema needs no new columns.
+ */
+export const wizardSteps: WizardStep[] = [
+  {
+    id: "focus",
+    type: "select",
+    question: "Where's the most time leaking right now?",
+    subtext: "Pick the area that eats the most hours each week.",
+    options: [
+      { value: "Lead follow-up & sales", label: "Lead follow-up & sales", hint: "Chasing leads, quotes, pipeline", score: 20 },
+      { value: "CRM & data entry", label: "CRM & data entry", hint: "Updating records, copy-paste work", score: 20 },
+      { value: "Customer support", label: "Customer support", hint: "Repetitive questions, busy inboxes", score: 18 },
+      { value: "Reporting & admin", label: "Reporting & admin", hint: "Weekly reports, invoicing", score: 18 },
+      { value: "Scheduling & operations", label: "Scheduling & operations", hint: "Booking, dispatch, coordination", score: 16 },
+      { value: "Something else", label: "Something else", hint: "Tell us in the next step", score: 10 },
+    ],
+  },
+  {
+    id: "detail",
+    type: "textarea",
+    question: "Walk us through it.",
+    subtext:
+      "What does that work look like today? The messier the better — that's exactly where an AI worker earns its keep.",
+    placeholder:
+      "e.g. Every morning I copy new leads from email into the CRM, then send the same 3 follow-ups by hand…",
+  },
+  {
+    id: "team",
+    type: "select",
+    question: "How big is your team?",
+    options: [
+      { value: "Just me", label: "Just me", score: 10 },
+      { value: "2–10", label: "2–10 people", score: 20 },
+      { value: "11–50", label: "11–50 people", score: 20 },
+      { value: "50+", label: "50+ people", score: 14 },
+    ],
+  },
+  {
+    id: "timeline",
+    type: "select",
+    question: "When do you want this handled?",
+    options: [
+      { value: "ASAP", label: "Yesterday — it's costing me now", score: 25 },
+      { value: "This quarter", label: "This quarter", score: 18 },
+      { value: "Exploring", label: "Just exploring for now", score: 8 },
+    ],
+  },
+  {
+    id: "tried",
+    type: "select",
+    question: "Tried to automate any of it before?",
+    subtext: "No wrong answer — it just helps us pitch you the right next step.",
+    optional: true,
+    options: [
+      { value: "Not yet", label: "Not yet", score: 8 },
+      { value: "DIY tools", label: "DIY tools (Zapier, Make, etc.)", score: 12 },
+      { value: "Hired help", label: "Hired a freelancer or agency", score: 14 },
+      { value: "Other", label: "Other", score: 8 },
+    ],
+  },
+  {
+    id: "name",
+    type: "text",
+    question: "Who are we sending the audit to?",
+    placeholder: "Jane Smith",
+  },
+  {
+    id: "email",
+    type: "email",
+    question: "Where should the audit land?",
+    subtext:
+      "We'll email your 1–3 highest-impact opportunities within one business day. No call required, no spam.",
+    placeholder: "jane@company.com",
+  },
+];
+
+export function leadScore(answers: Record<string, string>): number {
+  let score = 0;
+  for (const step of wizardSteps) {
+    if (!step.options) continue;
+    const opt = step.options.find((o) => o.value === answers[step.id]);
+    if (opt?.score) score += opt.score;
+  }
+  return Math.min(100, score);
+}
+
+/** Fold every wizard answer + the lead-fit score into a single Message string. */
+export function composeMessage(answers: Record<string, string>): string {
+  return [
+    `Primary time-sink: ${answers.focus || "—"}`,
+    ``,
+    `Details: ${answers.detail || "—"}`,
+    ``,
+    `Team size: ${answers.team || "—"}`,
+    `Timeline: ${answers.timeline || "—"}`,
+    `Tried before: ${answers.tried || "—"}`,
+    ``,
+    `Lead-fit score: ${leadScore(answers)}/100`,
+  ].join("\n");
+}

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -1,0 +1,120 @@
+/**
+ * Latest YouTube uploads shown as "build in public" social proof on the homepage.
+ *
+ * Keyless + auto-latest: we read the channel's public Atom feed
+ * (https://www.youtube.com/feeds/videos.xml?channel_id=UC…) at build time and
+ * refresh hourly (ISR) — no API key, no quota. The feed endpoint is reachable
+ * from CI/Netlify build servers (unlike the bot-blocked channel HTML page), so
+ * the grid auto-fills the moment a real channel ID is configured.
+ *
+ * Every fetch is wrapped: a missing channel ID, an empty channel, or any
+ * network failure returns [] — the section then renders an on-brand "subscribe"
+ * teaser instead of a broken grid, and the build never breaks.
+ */
+
+export const YOUTUBE_HANDLE = "@mifune-dev";
+export const YOUTUBE_CHANNEL_URL = `https://www.youtube.com/${YOUTUBE_HANDLE}`;
+
+/**
+ * The channel's UC… ID. Set `YOUTUBE_CHANNEL_ID` in the environment once the
+ * @mifune-dev channel is live (the public handle currently 404s while it's being
+ * built). The env value wins; until it's set the section shows the teaser state.
+ */
+export const YOUTUBE_CHANNEL_ID = process.env.YOUTUBE_CHANNEL_ID?.trim() || "";
+
+export interface YouTubeVideo {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  embedUrl: string;
+  thumbnail: string;
+  published: string; // ISO 8601
+}
+
+function decodeEntities(input: string): string {
+  return input
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)));
+}
+
+/** Parse the Atom feed into the latest `limit` videos. Regex-based so it needs
+ *  no XML parser dependency; the feed shape is stable and simple. */
+function parseFeed(xml: string, limit: number): YouTubeVideo[] {
+  const videos: YouTubeVideo[] = [];
+  // Each upload is one <entry>…</entry>; skip the channel header before the first.
+  const entries = xml.split("<entry>").slice(1);
+
+  for (const entry of entries) {
+    const id = entry.match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1]?.trim();
+    if (!id) continue;
+
+    // The entry's own <title> comes before <media:group>'s <media:title>.
+    const title = decodeEntities(
+      entry.match(/<title>([^<]*)<\/title>/)?.[1] ?? "",
+    ).trim();
+    const description = decodeEntities(
+      entry.match(/<media:description>([\s\S]*?)<\/media:description>/)?.[1] ?? "",
+    ).trim();
+    const published = entry.match(/<published>([^<]+)<\/published>/)?.[1]?.trim() ?? "";
+
+    videos.push({
+      id,
+      title: title || "Untitled",
+      description,
+      url: `https://www.youtube.com/watch?v=${id}`,
+      embedUrl: `https://www.youtube-nocookie.com/embed/${id}`,
+      thumbnail: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
+      published,
+    });
+
+    if (videos.length >= limit) break;
+  }
+
+  return videos;
+}
+
+export async function getLatestVideos(limit = 6): Promise<YouTubeVideo[]> {
+  if (!YOUTUBE_CHANNEL_ID) return [];
+
+  try {
+    const res = await fetch(
+      `https://www.youtube.com/feeds/videos.xml?channel_id=${YOUTUBE_CHANNEL_ID}`,
+      {
+        headers: { Accept: "application/atom+xml" },
+        next: { revalidate: 3600 }, // refresh the latest uploads hourly
+      },
+    );
+    if (!res.ok) return [];
+    return parseFeed(await res.text(), limit);
+  } catch {
+    return [];
+  }
+}
+
+/** ItemList of VideoObject JSON-LD — makes the embedded uploads eligible for
+ *  Google video rich results. Only emitted when real videos are present. */
+export function watchListSchema(videos: YouTubeVideo[]): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    itemListElement: videos.map((v, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "VideoObject",
+        name: v.title,
+        description: v.description || v.title,
+        thumbnailUrl: v.thumbnail,
+        uploadDate: v.published,
+        embedUrl: v.embedUrl,
+        url: v.url,
+      },
+    })),
+  };
+}

--- a/src/sections/AuditWizard.tsx
+++ b/src/sections/AuditWizard.tsx
@@ -1,0 +1,375 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { apiClient } from "@/utils/client";
+import { Contact } from "@/types";
+import {
+  wizardSteps,
+  composeMessage,
+  type WizardStep,
+} from "@/data/auditWizard";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const stepVariants = {
+  enter: (dir: number) => ({ x: dir > 0 ? 56 : -56, opacity: 0 }),
+  center: { x: 0, opacity: 1 },
+  exit: (dir: number) => ({ x: dir > 0 ? -56 : 56, opacity: 0 }),
+};
+
+function isValid(step: WizardStep, value: string): boolean {
+  if (step.optional) return true;
+  const v = (value || "").trim();
+  if (step.type === "email") return EMAIL_RE.test(v);
+  return v.length > 0;
+}
+
+export default function AuditWizard() {
+  const [index, setIndex] = useState(0);
+  const [direction, setDirection] = useState(1);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<Status>("idle");
+  const [website, setWebsite] = useState(""); // honeypot
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+
+  const step = wizardSteps[index];
+  const value = answers[step.id] ?? "";
+  const isLast = index === wizardSteps.length - 1;
+  const canAdvance = isValid(step, value);
+  const progress = ((index + 1) / wizardSteps.length) * 100;
+  const submitting = status === "loading";
+
+  // Auto-focus text inputs as each step enters.
+  useEffect(() => {
+    if (step.type !== "select") {
+      const t = setTimeout(() => inputRef.current?.focus(), 60);
+      return () => clearTimeout(t);
+    }
+  }, [index, step.type]);
+
+  const setAnswer = (id: string, val: string) =>
+    setAnswers((prev) => ({ ...prev, [id]: val }));
+
+  const goNext = () => {
+    if (isLast) {
+      submit();
+      return;
+    }
+    setDirection(1);
+    setIndex((i) => Math.min(i + 1, wizardSteps.length - 1));
+  };
+
+  const goBack = () => {
+    if (index === 0) return;
+    setDirection(-1);
+    setIndex((i) => Math.max(i - 1, 0));
+  };
+
+  const pickOption = (val: string) => {
+    setAnswer(step.id, val);
+    // Brief highlight, then advance — feels responsive without being jarring.
+    setDirection(1);
+    setTimeout(() => {
+      if (index === wizardSteps.length - 1) submit({ ...answers, [step.id]: val });
+      else setIndex((i) => Math.min(i + 1, wizardSteps.length - 1));
+    }, 240);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && step.type !== "textarea") {
+      e.preventDefault();
+      if (canAdvance) goNext();
+    }
+  };
+
+  async function submit(finalAnswers?: Record<string, string>) {
+    const data = finalAnswers ?? answers;
+
+    // Honeypot — bots fill the hidden field. Fake success, never hit the API.
+    if (website.trim()) {
+      setStatus("success");
+      return;
+    }
+
+    setStatus("loading");
+    const payload: Contact = {
+      Name: data.name || "",
+      Email: data.email || "",
+      Phone: "",
+      Message: composeMessage(data),
+      Referrer: "audit-wizard",
+    };
+
+    try {
+      const res = await apiClient.contactFormSubmit(payload);
+      setStatus(res.ok ? "success" : "error");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <section
+      id="audit"
+      className="relative scroll-mt-20 overflow-hidden bg-gradient-to-b from-background to-green-500/5 px-4 py-24"
+    >
+      {/* Ambient glow + grid */}
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,#80808014_1px,transparent_1px),linear-gradient(to_bottom,#80808014_1px,transparent_1px)] bg-[size:32px_32px] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_40%,#000_60%,transparent_100%)]" />
+      <div className="pointer-events-none absolute left-1/2 top-1/3 h-[420px] w-[620px] -translate-x-1/2 rounded-full bg-green-500/10 blur-[120px]" />
+
+      <div className="relative mx-auto max-w-2xl">
+        {/* Eyebrow */}
+        <div className="mb-8 text-center">
+          <p className="mb-3 font-montserrat text-sm font-medium uppercase tracking-widest text-muted-foreground">
+            Free AI Workflow Audit
+          </p>
+          <h2 className="font-montserrat text-3xl font-bold text-foreground md:text-4xl">
+            Get your{" "}
+            <span className="font-space text-green-500 drop-shadow-[0_0_15px_rgba(34,197,94,0.55)]">
+              free audit
+            </span>{" "}
+            in 60 seconds
+          </h2>
+        </div>
+
+        <div className="rounded-3xl border border-green-500/20 bg-card/80 p-6 shadow-2xl backdrop-blur-sm md:p-10">
+          <AnimatePresence mode="wait">
+            {status === "success" ? (
+              <SuccessScreen key="success" email={answers.email} />
+            ) : (
+              <motion.div
+                key="wizard"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                {/* Progress */}
+                <div className="mb-8">
+                  <div className="mb-2 flex items-center justify-between font-montserrat text-xs text-muted-foreground">
+                    <span>
+                      Step {index + 1} of {wizardSteps.length}
+                    </span>
+                    <span>{Math.round(progress)}%</span>
+                  </div>
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
+                    <motion.div
+                      className="h-full rounded-full bg-green-500"
+                      animate={{ width: `${progress}%` }}
+                      transition={{ type: "spring", stiffness: 140, damping: 22 }}
+                    />
+                  </div>
+                </div>
+
+                {/* Step */}
+                <div className="min-h-[320px]">
+                  <AnimatePresence mode="wait" custom={direction}>
+                    <motion.div
+                      key={step.id}
+                      custom={direction}
+                      variants={stepVariants}
+                      initial="enter"
+                      animate="center"
+                      exit="exit"
+                      transition={{ type: "spring", stiffness: 260, damping: 30 }}
+                      onKeyDown={onKeyDown}
+                    >
+                      <h3 className="font-montserrat text-2xl font-bold text-foreground md:text-3xl">
+                        {step.question}
+                      </h3>
+                      {step.subtext && (
+                        <p className="mt-3 font-montserrat text-base text-muted-foreground">
+                          {step.subtext}
+                        </p>
+                      )}
+
+                      <div className="mt-8">
+                        {step.type === "select" && step.options && (
+                          <div className="grid gap-3">
+                            {step.options.map((opt) => {
+                              const selected = value === opt.value;
+                              return (
+                                <button
+                                  key={opt.value}
+                                  type="button"
+                                  onClick={() => pickOption(opt.value)}
+                                  className={`group flex items-center justify-between gap-4 rounded-2xl border p-4 text-left transition-all duration-200 ${
+                                    selected
+                                      ? "border-green-500 bg-green-500/10"
+                                      : "border-border bg-background hover:border-green-500/50 hover:bg-green-500/5"
+                                  }`}
+                                >
+                                  <span>
+                                    <span className="block font-montserrat font-semibold text-foreground">
+                                      {opt.label}
+                                    </span>
+                                    {opt.hint && (
+                                      <span className="mt-0.5 block font-montserrat text-sm text-muted-foreground">
+                                        {opt.hint}
+                                      </span>
+                                    )}
+                                  </span>
+                                  <span
+                                    className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border transition-colors ${
+                                      selected
+                                        ? "border-green-500 bg-green-500 text-black"
+                                        : "border-border text-transparent group-hover:border-green-500/50"
+                                    }`}
+                                  >
+                                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                                    </svg>
+                                  </span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {step.type === "textarea" && (
+                          <textarea
+                            ref={(el) => {
+                              inputRef.current = el;
+                            }}
+                            rows={4}
+                            value={value}
+                            placeholder={step.placeholder}
+                            onChange={(e) => setAnswer(step.id, e.target.value)}
+                            className="w-full resize-none rounded-2xl border border-border bg-background px-5 py-4 font-montserrat text-base text-foreground transition-colors focus:border-green-500 focus:outline-none"
+                          />
+                        )}
+
+                        {(step.type === "text" || step.type === "email") && (
+                          <input
+                            ref={(el) => {
+                              inputRef.current = el;
+                            }}
+                            type={step.type === "email" ? "email" : "text"}
+                            value={value}
+                            placeholder={step.placeholder}
+                            onChange={(e) => setAnswer(step.id, e.target.value)}
+                            className="w-full rounded-2xl border border-border bg-background px-5 py-4 font-montserrat text-lg text-foreground transition-colors focus:border-green-500 focus:outline-none"
+                          />
+                        )}
+                      </div>
+                    </motion.div>
+                  </AnimatePresence>
+                </div>
+
+                {/* Honeypot */}
+                <div aria-hidden="true" style={{ position: "absolute", left: "-9999px", opacity: 0 }}>
+                  <label htmlFor="wizard-website">Website</label>
+                  <input
+                    id="wizard-website"
+                    type="text"
+                    tabIndex={-1}
+                    autoComplete="off"
+                    value={website}
+                    onChange={(e) => setWebsite(e.target.value)}
+                  />
+                </div>
+
+                {status === "error" && (
+                  <p role="alert" className="mt-6 font-montserrat text-sm text-red-400">
+                    Something went wrong. Please try again, or email us at{" "}
+                    <a href="mailto:hello@mifune.dev" className="font-semibold underline hover:text-red-300">
+                      hello@mifune.dev
+                    </a>
+                    .
+                  </p>
+                )}
+
+                {/* Controls — select steps auto-advance, so hide Continue there */}
+                <div className="mt-8 flex items-center justify-between gap-4">
+                  <button
+                    type="button"
+                    onClick={goBack}
+                    disabled={index === 0}
+                    className="font-montserrat text-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-0"
+                  >
+                    ← Back
+                  </button>
+
+                  {step.type !== "select" && (
+                    <button
+                      type="button"
+                      onClick={goNext}
+                      disabled={!canAdvance || submitting}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-green-500 px-7 py-3 font-montserrat text-base font-medium text-black shadow-lg transition-all duration-200 hover:bg-green-400 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {submitting ? (
+                        <>
+                          <span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-black border-t-transparent" />
+                          Sending…
+                        </>
+                      ) : isLast ? (
+                        "Get My Free Audit"
+                      ) : (
+                        "Continue"
+                      )}
+                    </button>
+                  )}
+                </div>
+
+                {step.optional && step.type === "select" && (
+                  <button
+                    type="button"
+                    onClick={goNext}
+                    className="mt-4 w-full text-center font-montserrat text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    Skip this one
+                  </button>
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        <p className="mt-6 text-center font-montserrat text-xs text-muted-foreground">
+          No spam, ever. We reply within one business day — no call required to start.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function SuccessScreen({ email }: { email?: string }) {
+  return (
+    <motion.div
+      key="success-inner"
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      className="flex flex-col items-center py-10 text-center"
+      role="alert"
+    >
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ type: "spring", stiffness: 200, damping: 14, delay: 0.1 }}
+        className="flex h-20 w-20 items-center justify-center rounded-full border border-green-500/30 bg-green-500/10"
+      >
+        <svg className="h-10 w-10 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <motion.path
+            initial={{ pathLength: 0 }}
+            animate={{ pathLength: 1 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.5}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+      </motion.div>
+      <h3 className="mt-6 font-montserrat text-2xl font-bold text-foreground">
+        You&apos;re in. Audit incoming.
+      </h3>
+      <p className="mt-3 max-w-md font-montserrat text-muted-foreground">
+        We&apos;ll email your 1–3 highest-impact AI opportunities to{" "}
+        <span className="font-semibold text-foreground">{email || "your inbox"}</span>{" "}
+        within one business day. If it&apos;s not there, check your spam folder.
+      </p>
+    </motion.div>
+  );
+}

--- a/src/sections/WatchSection.tsx
+++ b/src/sections/WatchSection.tsx
@@ -1,0 +1,16 @@
+import { getLatestVideos, watchListSchema } from "@/lib/youtube";
+import JsonLd from "@/components/seo/JsonLd";
+import WatchShowcase from "./WatchShowcase";
+
+// Async server component: pulls the channel's latest uploads from the keyless
+// Atom feed at build time (hourly ISR) and hands them to the client showcase.
+// Emits VideoObject JSON-LD only when real uploads are present.
+export default async function WatchSection() {
+  const videos = await getLatestVideos(6);
+  return (
+    <>
+      {videos.length > 0 && <JsonLd data={watchListSchema(videos)} />}
+      <WatchShowcase videos={videos} />
+    </>
+  );
+}

--- a/src/sections/WatchShowcase.tsx
+++ b/src/sections/WatchShowcase.tsx
@@ -1,0 +1,184 @@
+"use client";
+import { useState } from "react";
+import Image from "next/image";
+import { motion } from "framer-motion";
+import { FaYoutube, FaPlay } from "react-icons/fa";
+import {
+  YOUTUBE_CHANNEL_URL,
+  YOUTUBE_HANDLE,
+  type YouTubeVideo,
+} from "@/lib/youtube";
+
+function formatDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short" });
+}
+
+/** One click-to-play card. The heavy YouTube player only loads on click — the
+ *  resting state is a single thumbnail image, so the section stays fast. */
+function VideoCard({ video, index }: { video: YouTubeVideo; index: number }) {
+  const [playing, setPlaying] = useState(false);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5, delay: index * 0.08 }}
+      className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-green-500/40"
+    >
+      <div className="relative aspect-video w-full overflow-hidden bg-black">
+        {playing ? (
+          <iframe
+            src={`${video.embedUrl}?autoplay=1&rel=0`}
+            title={video.title}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            className="absolute inset-0 h-full w-full"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setPlaying(true)}
+            aria-label={`Play: ${video.title}`}
+            className="absolute inset-0 h-full w-full cursor-pointer"
+          >
+            <Image
+              src={video.thumbnail}
+              alt={video.title}
+              fill
+              sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+            <span className="absolute inset-0 bg-black/10 transition-colors group-hover:bg-black/30" />
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span className="flex h-16 w-16 items-center justify-center rounded-full bg-green-500/90 shadow-[0_0_30px_rgba(34,197,94,0.5)] transition-transform duration-300 group-hover:scale-110">
+                <FaPlay className="ml-1 h-5 w-5 text-black" />
+              </span>
+            </span>
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col p-5">
+        <h3 className="line-clamp-2 font-montserrat text-sm font-semibold leading-snug text-foreground transition-colors group-hover:text-green-500">
+          {video.title}
+        </h3>
+        {video.published && (
+          <p className="mt-auto pt-3 font-montserrat text-xs text-muted-foreground">
+            {formatDate(video.published)}
+          </p>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function SectionHeader({ subtitle }: { subtitle: string }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="mb-16 text-center"
+    >
+      <p className="mb-4 flex items-center justify-center gap-2 font-montserrat text-sm font-medium uppercase tracking-widest text-muted-foreground">
+        <FaYoutube className="h-5 w-5 text-red-500" />
+        Watch &amp; Learn
+      </p>
+      <h2 className="font-montserrat text-3xl font-bold text-foreground md:text-4xl">
+        See how we build,{" "}
+        <span className="text-green-500">in public.</span>
+      </h2>
+      <p className="mx-auto mt-4 max-w-2xl font-montserrat text-lg text-muted-foreground">
+        {subtitle}
+      </p>
+    </motion.div>
+  );
+}
+
+function ChannelCta({ label }: { label: string }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5, delay: 0.3 }}
+      className="mt-12 text-center"
+    >
+      <a
+        href={YOUTUBE_CHANNEL_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 rounded-full bg-red-600 px-6 py-3 font-montserrat text-sm font-semibold text-white shadow-lg transition-colors hover:bg-red-500"
+      >
+        <FaYoutube className="h-5 w-5" />
+        {label}
+      </a>
+    </motion.div>
+  );
+}
+
+export default function WatchShowcase({ videos }: { videos: YouTubeVideo[] }) {
+  const hasVideos = videos.length > 0;
+
+  return (
+    <section id="watch" className="relative scroll-mt-20 px-4 py-24">
+      <div className="mx-auto max-w-5xl">
+        {hasVideos ? (
+          <>
+            <SectionHeader subtitle="Real AI-engineering builds, walkthroughs, and breakdowns — the same techniques we deploy for clients, explained end to end." />
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {videos.map((video, index) => (
+                <VideoCard key={video.id} video={video} index={index} />
+              ))}
+            </div>
+            <ChannelCta label="See every build on YouTube" />
+          </>
+        ) : (
+          /* Teaser state — shown until the channel is live / has uploads. */
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+            className="mx-auto max-w-2xl overflow-hidden rounded-2xl border border-border bg-card p-10 text-center md:p-14"
+          >
+            <span className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red-600/10 ring-1 ring-red-600/30">
+              <FaYoutube className="h-8 w-8 text-red-500" />
+            </span>
+            <p className="mb-3 font-montserrat text-sm font-medium uppercase tracking-widest text-muted-foreground">
+              Watch &amp; Learn
+            </p>
+            <h2 className="font-montserrat text-3xl font-bold text-foreground md:text-4xl">
+              See how we build,{" "}
+              <span className="text-green-500">in public.</span>
+            </h2>
+            <p className="mx-auto mt-4 max-w-xl font-montserrat text-lg text-muted-foreground">
+              We&apos;re publishing AI-engineering builds and breakdowns on
+              YouTube — the same techniques we deploy for clients. Subscribe and
+              build alongside us.
+            </p>
+            <div className="mt-8">
+              <a
+                href={YOUTUBE_CHANNEL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full bg-red-600 px-6 py-3 font-montserrat text-sm font-semibold text-white shadow-lg transition-colors hover:bg-red-500"
+              >
+                <FaYoutube className="h-5 w-5" />
+                Subscribe on YouTube
+              </a>
+              <p className="mt-4 font-mono text-xs text-muted-foreground">
+                {YOUTUBE_HANDLE}
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Why

You're building an AI-engineering catalogue on YouTube and want it featured as **build-in-public social proof** — and you want it **auto-latest** (no manual updates). This adds a *Watch & Learn* section that pulls your channel's newest uploads on its own.

## What it is

A native, **keyless, auto-updating** video section on the homepage (`#watch`), sitting right after the open-source proof:

- **Auto-latest** — reads your channel's public **Atom feed** (`/feeds/videos.xml?channel_id=…`) at build time and refreshes **hourly (ISR)**. No API key, no quota, no manual list to maintain. New upload → it appears within the hour.
- **Click-to-play lite-embed grid** — the resting state is a single thumbnail; the heavy YouTube player loads **only on click**. Fast, and it preserves the perf/SEO work from the SERP PRs.
- **On-brand** — your dark/green design system, springy reveals, a green play button. No rented off-brand iframe wall.
- **VideoObject JSON-LD** (ItemList) emitted when uploads are present → eligible for Google **video rich results**, reinforcing the SERP effort.
- **Crash-proof** — a missing/empty/unreachable channel returns `[]` and the build never breaks.

## ⚠️ Two operator steps to light it up

The section ships in a polished **"subscribe / coming soon" teaser** state until both are done:

1. **Claim/publish the `@mifune-dev` handle.** It currently **404s** (verified) — so the section's subscribe CTA *and* your existing footer/socials links to it are dead until the channel goes live.
2. **Set `YOUTUBE_CHANNEL_ID`** (the `UC…` id) in Netlify env. The instant it's set, the teaser becomes the auto-latest grid. (Tell me the handle/ID once it's live and I'll hardcode it as the default.)

> The RSS feed endpoint is confirmed reachable from datacenter/CI IPs (HTTP 200), so this works on Netlify's build servers — only the channel's *HTML page* is bot-blocked, which is why I avoid scraping it and drive everything off the channel ID.

## Why "auto-latest" this way (no API key)

YouTube's Data API needs a key + quota and rotates. The **Atom feed is public, keyless, and cache-friendly** — it's the same `fetch(… next:{revalidate:3600})` ISR pattern the open-source star-count section already uses in production here. Lowest-maintenance path that still updates itself.

## Verify

- `npm run build` ✅ green in **both** states (no env → teaser; `YOUTUBE_CHANNEL_ID=…` → live grid that fetched real uploads at build).
- Parser unit-tested against a **real** Atom feed — videoId / title / date / description all extract correctly.
- **Reviewer:** open the Netlify preview → the *Watch & Learn* teaser renders after the open-source section. To preview the grid, set `YOUTUBE_CHANNEL_ID` to any `UC…` id in the preview env and redeploy.

## Notes

- **Stacked on PR #45** (audit wizard) → #44 → `development`, to stay conflict-free (all touch `page.tsx`). Merge the stack in order; this retargets to `development` after #45.
- Prefer to **hide the section until there are real videos** instead of showing the teaser? One-line change — say the word.
- Files: `src/lib/youtube.ts`, `src/sections/WatchSection.tsx` (async server), `src/sections/WatchShowcase.tsx` (client), `page.tsx` insert, `next.config.mjs` (`i.ytimg.com` whitelist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)