### PR TITLE
feat: Getting Started with OpenHarness on-ramp + stale-content fixes

### DIFF
--- a/posts/openharness-getting-started.md
+++ b/posts/openharness-getting-started.md
@@ -1,0 +1,70 @@
+---
+title: "Getting Started with OpenHarness: From a Bare Host to a Running AI Sandbox"
+date: "2026-07-02"
+excerpt: "A concise on-ramp to OpenHarness — the open, isolated environment every Mifune AI worker runs inside. Go from a fresh host to a running, authenticated sandbox in a few commands, then follow the canonical docs for depth."
+categories: ["OpenHarness", "Getting Started", "AI Infrastructure", "Developer Guide"]
+author:
+  name: "Ryan Eggleston"
+  picture: "https://avatars.githubusercontent.com/u/40816745?s=96&v=4"
+  linkedin: https://www.linkedin.com/in/ryan-eggleston
+---
+
+OpenHarness is the open, isolated operating environment every Mifune AI worker runs inside — one project, one hardened Docker sandbox, with **you owning every configuration from day one**. This post is a concise on-ramp: enough to get a sandbox running and authenticated on your own machine. It deliberately does **not** reproduce the full setup manual — for depth, follow the canonical docs:
+
+- **Docs:** [oh.mifune.dev/docs](https://oh.mifune.dev/docs)
+- **Install reference:** [github.com/mifunedev/openharness#-install](https://github.com/mifunedev/openharness#-install)
+
+## What you'll need
+
+A host (Linux, macOS, or WSL2) with:
+
+- [Docker](https://docs.docker.com/get-docker/) with the Compose plugin
+- [Git](https://git-scm.com/)
+- `make` (build-essential)
+
+## 1. Clone and own
+
+The recommended path is **clone-and-own**: clone upstream, then make it yours.
+
+```bash
+git clone https://github.com/mifunedev/openharness.git ~/.openharness
+cd ~/.openharness
+```
+
+**Edit `harness.yaml` before you build.** Set your `sandbox.name`, `sandbox.timezone`, `git.user_name`, and `git.user_email` (plus any optional installs). Secrets never go in this file — they live in `.devcontainer/.env`.
+
+```bash
+nano harness.yaml
+```
+
+Then build the image and open a shell inside the sandbox:
+
+```bash
+make sandbox && make shell
+```
+
+That's already a working sandbox.
+
+## 2. Enter the sandbox
+
+Two ways in:
+
+- **VS Code Dev Containers** → _Attach to Running Container_ (recommended — works locally or over Remote-SSH)
+- or `make shell` from the terminal
+
+## 3. Authenticate
+
+The simplest cross-provider path: launch the agent, run `/login`, and pick **device mode** — you get a code and a URL that work even on a headless or remote host. Where a provider exposes a one-liner, these are equivalents:
+
+```bash
+claude auth login            # Claude Code
+codex login --device-auth    # Codex
+```
+
+From here you have an authenticated, isolated agent sandbox. For a private-repo `origin` with `mifunedev/openharness` as `upstream`, Slack gateways, and the full end-to-end walkthrough, keep going in the [canonical docs](https://oh.mifune.dev/docs).
+
+---
+
+### Prefer we build it for you?
+
+Getting started yourself is the developer path. If you'd rather hand it off, that's what Mifune does — we design, build, and manage the AI workers that run your business, all on OpenHarness. [Get a free AI Workflow Audit →](/#audit)

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -43,14 +43,6 @@ const FLAGSHIP: CuratedRepo[] = [
     fallbackStars: 13,
     fallbackLanguage: "Python",
   },
-  {
-    owner: "ryaneggz",
-    name: "mifune",
-    tagline:
-      "The Pi + Mom agent shell that turns OpenHarness into a hands-on, self-improving coding agent.",
-    fallbackStars: 1,
-    fallbackLanguage: "TypeScript",
-  },
 ];
 
 async function fetchRepo(repo: CuratedRepo): Promise<FlagshipRepo> {

--- a/src/sections/AboutSection.tsx
+++ b/src/sections/AboutSection.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import Image from "next/image";
+import Link from "next/link";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 
 const AboutSection = () => {
@@ -109,6 +110,23 @@ const AboutSection = () => {
             data stays private, and you own every configuration from day
             one.
           </p>
+          <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Link
+              href="/blog/openharness-getting-started"
+              className="inline-flex w-fit items-center gap-2 rounded-full border border-green-500/40 bg-green-500/10 px-5 py-2 font-montserrat text-sm font-medium text-green-500 transition-colors hover:bg-green-500/20"
+            >
+              Get started with OpenHarness →
+            </Link>
+            <span className="font-montserrat text-sm text-muted-foreground">
+              Want it built for you?{" "}
+              <Link
+                href="/#audit"
+                className="text-foreground underline-offset-4 transition-colors hover:text-green-500 hover:underline"
+              >
+                Get a free audit
+              </Link>
+            </span>
+          </div>
         </motion.div>
       </div>
     </section>

--- a/src/sections/FooterSection.tsx
+++ b/src/sections/FooterSection.tsx
@@ -128,6 +128,11 @@ const FooterSection = () => {
                 </Link>
               </li>
               <li>
+                <Link href="/blog/openharness-getting-started" className="hover:text-green-500 transition-colors duration-200">
+                  Getting Started
+                </Link>
+              </li>
+              <li>
                 <a href="https://github.com/mifunedev" target="_blank" rel="noopener noreferrer" className="hover:text-green-500 transition-colors duration-200">
                   GitHub
                 </a>

--- a/src/sections/OpenSourceShowcase.tsx
+++ b/src/sections/OpenSourceShowcase.tsx
@@ -34,7 +34,7 @@ export default function OpenSourceShowcase({
         </motion.div>
 
         {/* Repo cards */}
-        <div className="grid gap-6 md:grid-cols-3">
+        <div className="grid gap-6 md:grid-cols-2">
           {repos.map((repo, index) => (
             <motion.a
               key={repo.fullName}


### PR DESCRIPTION
## What

Adds a concise public **"Getting Started with OpenHarness"** on-ramp (blog post) to the mifune.dev marketing site, and fixes stale OpenHarness marketing content. Opened for assessment.

## Changes

- **New post** `posts/openharness-getting-started.md` — a concise on-ramp: *what is OpenHarness* → host prerequisites → **clone-and-own** with `harness.yaml` edited **before** `make sandbox` → VS Code attach / `make shell` → `/login` **device-mode** auth. Every "go deeper" reference is a **link** to the canonical docs (`oh.mifune.dev/docs`, `github.com/mifunedev/openharness#-install`) rather than a reproduction of them; closes with a bridge back to the managed offering.
- **Stale-content fix** — `src/lib/github.ts` removes the extracted/unused `ryaneggz/mifune` flagship repo; `src/sections/OpenSourceShowcase.tsx` grid `md:grid-cols-3` → `md:grid-cols-2` so the two remaining repos (openharness, orchestra) render balanced.
- **Cross-links** — `AboutSection.tsx` "Powered by OpenHarness" callout gains a **"Get started with OpenHarness"** link plus a **"Want it built for you? Get a free audit"** bridge; `FooterSection.tsx` Developers column gains a **"Getting Started"** link. The primary **"Launch OpenHarness"** footer CTA is **unchanged**.

## Verification

- `npx tsc --noEmit` clean · `next lint` clean · `next build` green (`/blog/openharness-getting-started` statically generated; blog index now 7 posts)
- Browser render confirmed (screenshots) for the post + About callout + footer + 2-card showcase

## Notes for the reviewer

- A copy audit of the OpenHarness claims (`AboutSection.tsx`, `faqs.ts`, `pricing.ts`) found **no inaccuracies** vs. the canonical narrative — no brand copy was changed.
- Harness workflow artifacts (`tasks/openharness-getting-started/` PRD/critique/progress) were intentionally **not** committed to keep this repo clean — available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
