### PR TITLE
feat: default theme from the client timezone hour

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,9 @@ import JsonLd from "@/components/seo/JsonLd";
 import { ThemeProvider } from "@/components/theme-provider";
 import { GA_ID, NODE_ENV, SITE_URL } from "@/config/app";
 import { organizationSchema, websiteSchema } from "@/lib/schema";
+import { buildTimeOfDayThemeScript } from "@/lib/time-of-day-theme";
+
+const timeOfDayThemeScript = buildTimeOfDayThemeScript();
 
 const montserrat = Montserrat({
   subsets: ["latin"],
@@ -86,10 +89,12 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#f6f3ec" },
-    { media: "(prefers-color-scheme: dark)", color: "#000000" },
-  ],
+  // Deliberately NOT keyed on `prefers-color-scheme`. The rendered theme is
+  // resolved from the client's local hour (plus any explicit choice), which
+  // the OS preference cannot predict — an OS-light visitor at 20:00 would
+  // otherwise get eggshell mobile chrome above a dark page. A single value
+  // matching the SSR/no-JS default (dark) can never contradict conditionally.
+  themeColor: "#000000",
   width: "device-width",
   initialScale: 1,
 };
@@ -105,6 +110,14 @@ export default function RootLayout({
       className={`${montserrat.variable} ${spaceGrotesk.variable}`}
       suppressHydrationWarning
     >
+      <head>
+        {/*
+          Must stay synchronous, in <head>, and ahead of next-themes' own
+          script (which renders inside <body>) so the time-of-day default is
+          committed before anything paints. No transition is introduced.
+        */}
+        <script dangerouslySetInnerHTML={{ __html: timeOfDayThemeScript }} />
+      </head>
       <body className="font-montserrat">
         <JsonLd data={organizationSchema()} />
         <JsonLd data={websiteSchema()} />

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -10,9 +10,26 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { THEME_AUTO_STORAGE_KEY } from "@/lib/time-of-day-theme";
 
 export function ModeToggle() {
   const { setTheme } = useTheme();
+
+  // Every selection here is an explicit choice, so it must permanently end the
+  // time-of-day default — including the case where the user picks the same
+  // value the clock had already auto-applied. Clearing the marker is what makes
+  // that airtight instead of heuristic.
+  const chooseTheme = React.useCallback(
+    (theme: string) => {
+      try {
+        window.localStorage.removeItem(THEME_AUTO_STORAGE_KEY);
+      } catch {
+        // Storage unavailable: next-themes' own setTheme is best-effort too.
+      }
+      setTheme(theme);
+    },
+    [setTheme],
+  );
 
   return (
     <DropdownMenu>
@@ -30,16 +47,19 @@ export function ModeToggle() {
       <DropdownMenuContent align="end">
         <DropdownMenuItem
           className="min-h-11"
-          onClick={() => setTheme("light")}
+          onClick={() => chooseTheme("light")}
         >
           Light
         </DropdownMenuItem>
-        <DropdownMenuItem className="min-h-11" onClick={() => setTheme("dark")}>
+        <DropdownMenuItem
+          className="min-h-11"
+          onClick={() => chooseTheme("dark")}
+        >
           Dark
         </DropdownMenuItem>
         <DropdownMenuItem
           className="min-h-11"
-          onClick={() => setTheme("system")}
+          onClick={() => chooseTheme("system")}
         >
           System
         </DropdownMenuItem>

--- a/src/lib/time-of-day-theme.ts
+++ b/src/lib/time-of-day-theme.ts
@@ -1,0 +1,118 @@
+/**
+ * Client-local time-of-day theme default.
+ *
+ * The browser's own wall-clock hour is the client-timezone signal:
+ * `new Date().getHours()` already resolves in the visitor's zone and is
+ * DST-correct by construction. No `Intl` lookup, no geo-IP, no server clock,
+ * no build-time constant.
+ *
+ * This module is the single source of the boundary constants. The inline
+ * bootstrap script is built from those same constants (see
+ * `buildTimeOfDayThemeScript`) so the two can never drift apart.
+ */
+
+/** 07:00 inclusive — start of the light window. */
+export const DAY_START_HOUR = 7;
+
+/** 18:00 inclusive — start of the dark window. */
+export const NIGHT_START_HOUR = 18;
+
+/** next-themes' storage key. Must match the `storageKey` the provider uses. */
+export const THEME_STORAGE_KEY = "theme";
+
+/**
+ * Companion key holding the value the bootstrap script last auto-applied.
+ *
+ * next-themes re-applies `defaultTheme` in a mount effect, so a script that
+ * only sets the class is overwritten right after hydration. Seeding
+ * `localStorage["theme"]` is therefore structurally required here — and this
+ * marker is what keeps a required seed from freezing the default forever:
+ * while `theme === theme-auto`, no human has actually chosen anything, so the
+ * hour is re-resolved on every load. Any explicit selection clears the marker
+ * and permanently ends the time rule.
+ */
+export const THEME_AUTO_STORAGE_KEY = "theme-auto";
+
+export type TimeOfDayTheme = "light" | "dark";
+
+/**
+ * Mobile browser-chrome colours, matching the `--background` tokens in
+ * `globals.css` (`0 0% 100%` light, `240 10% 3.9%` dark).
+ *
+ * The static `viewport.themeColor` cannot track a theme resolved from the
+ * client clock, so the bootstrap script keeps the `<meta name="theme-color">`
+ * in sync. Without this the feature would introduce a mismatch it did not have
+ * before: pre-change the page was always dark, so dark chrome matched; a light
+ * 14:00 page under dark chrome is a regression this feature would have caused.
+ */
+export const THEME_COLORS: Record<TimeOfDayTheme, string> = {
+  light: "#ffffff",
+  dark: "#09090b",
+};
+
+/**
+ * Pure boundary rule. Reads no `Date`, no `window`, no `localStorage` — the
+ * hour is always supplied by the caller, which is what keeps the client-side
+ * clock read in exactly one place per page load.
+ *
+ * | Local hour  | Theme |
+ * | ----------- | ----- |
+ * | 00:00–06:59 | dark  |
+ * | 07:00–17:59 | light |
+ * | 18:00–23:59 | dark  |
+ */
+export function resolveTimeOfDayTheme(hour: number): TimeOfDayTheme {
+  return hour >= NIGHT_START_HOUR || hour < DAY_START_HOUR ? "dark" : "light";
+}
+
+/**
+ * Build the synchronous inline `<head>` script that applies the time-of-day
+ * default before anything paints and before next-themes' own script runs.
+ *
+ * Precedence, evaluated once per document load:
+ *
+ * - `theme` absent            → resolve by hour, write both keys, apply.
+ * - `theme === theme-auto`    → still an unmade choice → re-resolve by hour,
+ *                               write both keys, apply.
+ * - otherwise                 → a real explicit choice → touch neither storage
+ *                               nor the class; next-themes owns both.
+ *
+ * In every branch the resolved colour is mirrored into
+ * `<meta name="theme-color">`, which Next renders ahead of this script, so the
+ * mobile chrome cannot disagree with the painted page.
+ *
+ * The whole body is exception-wrapped: if `localStorage` is unavailable or
+ * throws, the script does nothing at all and the page falls through to
+ * next-themes' pre-existing `defaultTheme` behaviour.
+ *
+ * `theme-auto` is written before `theme` on purpose. If the second write
+ * fails (quota, denied storage) the surviving state is `theme` absent, which
+ * simply re-resolves next load — the opposite order would leave a seeded
+ * `theme` with no marker and freeze it as a fake explicit choice.
+ */
+export function buildTimeOfDayThemeScript(): string {
+  return [
+    "(function(){try{",
+    `var K=${JSON.stringify(THEME_STORAGE_KEY)},A=${JSON.stringify(THEME_AUTO_STORAGE_KEY)};`,
+    `var DAY=${DAY_START_HOUR},NIGHT=${NIGHT_START_HOUR};`,
+    `var C=${JSON.stringify(THEME_COLORS)};`,
+    "var s=window.localStorage;",
+    "var raw=s.getItem(K),auto=s.getItem(A),t;",
+    "if(raw!==null&&raw!==auto){",
+    // An explicit choice: never touch storage or the class (next-themes owns
+    // both). Only mirror the resolved colour into the chrome meta.
+    "t=raw==='light'?'light':raw==='dark'?'dark':(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');",
+    "}else{",
+    "var h=new Date().getHours();",
+    "t=(h>=NIGHT||h<DAY)?'dark':'light';",
+    "s.setItem(A,t);s.setItem(K,t);",
+    "var e=document.documentElement;",
+    "e.classList.remove('light','dark');",
+    "e.classList.add(t);",
+    "e.style.colorScheme=t;",
+    "}",
+    "var m=document.querySelector('meta[name=\"theme-color\"]');",
+    "if(m&&C[t])m.setAttribute('content',C[t]);",
+    "}catch(err){}})();",
+  ].join("");
+}


### PR DESCRIPTION
Resolves the theme from the **client-side** browser hour when the user has made no explicit choice: `hour >= 18 || hour < 7` → dark, else light, in a synchronous `<head>` script that runs before next-themes.

## Why this seeds storage, and why a bare seed would be a bug

next-themes re-applies the theme in a **mount effect**:

```js
useState(() => H(storageKey, defaultTheme));       // localStorage || defaultTheme
useEffect(() => { S(forcedTheme ?? theme) }, ...); // re-applies on mount
```

So a script that only sets the class is overwritten back to `defaultTheme="dark"` right after hydration — a visible light→dark flash. Seeding is structurally required.

But a **bare seed freezes the default forever after the first visit**: the seeded value is indistinguishable from an explicit click, so a visitor who first lands at 20:00 is stuck in dark at 2pm the next day. Two independent reviewers rejected the first design for exactly this.

A companion `theme-auto` marker records what was auto-applied. While `theme === theme-auto` nobody has actually chosen, so the hour is **re-resolved on every load**. Any selection in the toggle clears the marker — which also covers the user who picks the value the clock had already chosen, the one case a value-comparison alone cannot distinguish.

`theme-auto` is written *before* `theme` on purpose: if the second write fails, the surviving state is `theme` absent, which simply re-resolves. The other order would leave a seeded `theme` with no marker and freeze it as a fake explicit choice.

## theme-color

`viewport.themeColor` was keyed on `prefers-color-scheme`, so an OS-light visitor at 20:00 got eggshell mobile chrome above a dark page. A single static value would instead leave dark chrome above the new **light daytime page** — a mismatch this feature would have introduced, since previously the page was always dark. The script now mirrors the resolved colour into the meta tag, which Next renders ahead of it.

## Verification

- `npx tsc --noEmit` ✅ · `npm run build` ✅ · `npm run lint` ✅
- Timezone matrix on the running production build, expectation re-derived in-browser:
  Auckland h9 light · Denver h15 light · UTC h21 dark · Tokyo h6 dark · Kolkata h2 dark · Chatham h10 light
- Chrome meta tracks: Denver h15 → `#ffffff` with body `rgb(255,255,255)`; UTC h21 → `#09090b` with body `rgb(9,9,11)`
- **Anti-freeze, persistent profile, browser relaunched under a new TZ:** load 1 UTC h21 → dark (`theme=dark`), load 2 Denver h15 → **light**. A sentinel key survived between loads, proving load 2 read genuinely seeded storage rather than a fresh profile.
- **Stickiness, the hard case:** auto-dark at UTC h21, then explicitly click **Dark** → marker clears to `null`; reload at Denver h15 (clock says light) → stays **dark**.
- Light / Dark / System still behave as before; storage-denied run falls through cleanly with no page errors.

## Known limitations

- Sub-frame flash is not directly observable by a post-load assertion; the claim rests on script position in the built HTML (ours at 4155, `</head>` 4601, next-themes 6170) plus the fact that no day-zone run ever flipped after hydration.
- `next-pwa` is active in production, so returning visitors may be served a precached shell until the service worker updates.
- Only the storage-*unavailable* variant was exercised in-browser; a throwing storage getter hits the same `try` by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)