### PR TITLE
fix: keep the automatic theme out of storage, and let OS dark outrank the hour

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,9 +7,6 @@ import JsonLd from "@/components/seo/JsonLd";
 import { ThemeProvider } from "@/components/theme-provider";
 import { GA_ID, NODE_ENV, SITE_URL } from "@/config/app";
 import { organizationSchema, websiteSchema } from "@/lib/schema";
-import { buildTimeOfDayThemeScript } from "@/lib/time-of-day-theme";
-
-const timeOfDayThemeScript = buildTimeOfDayThemeScript();
 
 const montserrat = Montserrat({
   subsets: ["latin"],
@@ -110,14 +107,6 @@ export default function RootLayout({
       className={`${montserrat.variable} ${spaceGrotesk.variable}`}
       suppressHydrationWarning
     >
-      <head>
-        {/*
-          Must stay synchronous, in <head>, and ahead of next-themes' own
-          script (which renders inside <body>) so the time-of-day default is
-          committed before anything paints. No transition is introduced.
-        */}
-        <script dangerouslySetInnerHTML={{ __html: timeOfDayThemeScript }} />
-      </head>
       <body className="font-montserrat">
         <JsonLd data={organizationSchema()} />
         <JsonLd data={websiteSchema()} />

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
@@ -10,26 +9,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { THEME_AUTO_STORAGE_KEY } from "@/lib/time-of-day-theme";
 
 export function ModeToggle() {
-  const { setTheme } = useTheme();
-
-  // Every selection here is an explicit choice, so it must permanently end the
-  // time-of-day default — including the case where the user picks the same
-  // value the clock had already auto-applied. Clearing the marker is what makes
-  // that airtight instead of heuristic.
-  const chooseTheme = React.useCallback(
-    (theme: string) => {
-      try {
-        window.localStorage.removeItem(THEME_AUTO_STORAGE_KEY);
-      } catch {
-        // Storage unavailable: next-themes' own setTheme is best-effort too.
-      }
-      setTheme(theme);
-    },
-    [setTheme],
-  );
+  // Every selection here is an explicit choice, and `setTheme` is all it takes
+  // to record one: the automatic default never writes storage, so the mere
+  // presence of a stored value permanently ends the automatic path — including
+  // when the user picks the same value the clock had already applied.
+  const { setTheme: chooseTheme } = useTheme();
 
   return (
     <DropdownMenu>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -2,8 +2,53 @@
 
 import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
+import {
+  AUTO_THEME_ATTRIBUTE,
+  THEME_CHOICE_STORAGE_KEY,
+  buildTimeOfDayThemeScript,
+  type TimeOfDayTheme,
+} from "@/lib/time-of-day-theme"
 
-export function ThemeProvider({ children, ...props }: React.ComponentProps<typeof NextThemesProvider>) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+const timeOfDayThemeScript = buildTimeOfDayThemeScript()
+
+/**
+ * The theme the bootstrap script auto-applied, read back off `<html>`.
+ *
+ * Undefined on the server and whenever an explicit choice was in play — in both
+ * cases next-themes falls back to the `defaultTheme` the caller passed.
+ */
+function readAutoTheme(): TimeOfDayTheme | undefined {
+  if (typeof document === "undefined") return undefined
+  const applied = document.documentElement.getAttribute(AUTO_THEME_ATTRIBUTE)
+  return applied === "light" || applied === "dark" ? applied : undefined
 }
 
+export function ThemeProvider({ children, ...props }: React.ComponentProps<typeof NextThemesProvider>) {
+  return (
+    <NextThemesProvider
+      {...props}
+      storageKey={THEME_CHOICE_STORAGE_KEY}
+      // Handing the auto-applied theme to next-themes as its default is what
+      // keeps the automatic path out of storage entirely. next-themes reads
+      // `localStorage[storageKey] || defaultTheme` once, in a state
+      // initialiser, then re-applies that value in a mount effect — so without
+      // this the effect would overwrite the bootstrap's result, and the only
+      // other way to satisfy it is to persist the default, which is exactly
+      // what leaks the automatic theme into other tabs.
+      defaultTheme={readAutoTheme() ?? props.defaultTheme}
+    >
+      {/*
+        Renders immediately after next-themes' own inline script, which applies
+        `localStorage[storageKey] || defaultTheme` from values serialised during
+        the *server* render and would otherwise clobber the automatic theme.
+        Both scripts are parser-blocking and nothing paintable precedes either,
+        so the last write still lands before first paint.
+      */}
+      <script
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: timeOfDayThemeScript }}
+      />
+      {children}
+    </NextThemesProvider>
+  )
+}

--- a/src/lib/time-of-day-theme.ts
+++ b/src/lib/time-of-day-theme.ts
@@ -1,10 +1,17 @@
 /**
- * Client-local time-of-day theme default.
+ * Client-local automatic theme default.
  *
  * The browser's own wall-clock hour is the client-timezone signal:
  * `new Date().getHours()` already resolves in the visitor's zone and is
  * DST-correct by construction. No `Intl` lookup, no geo-IP, no server clock,
  * no build-time constant.
+ *
+ * Two rules compose into the automatic default, and the order matters:
+ *
+ * 1. `prefers-color-scheme: dark` is a *declared* preference — the only channel
+ *    a platform gives a user to say "light surfaces hurt me". It wins outright.
+ * 2. The hour is an *inferred* preference, and may only ever upgrade light →
+ *    dark, never dark → light.
  *
  * This module is the single source of the boundary constants. The inline
  * bootstrap script is built from those same constants (see
@@ -17,21 +24,44 @@ export const DAY_START_HOUR = 7;
 /** 18:00 inclusive — start of the dark window. */
 export const NIGHT_START_HOUR = 18;
 
-/** next-themes' storage key. Must match the `storageKey` the provider uses. */
-export const THEME_STORAGE_KEY = "theme";
+/**
+ * next-themes' storage key.
+ *
+ * It holds an explicit user choice and **nothing else**. The automatic default
+ * is never written to storage, which is precisely what stops it propagating
+ * between tabs: `storage` events fire in every *other* document of the origin,
+ * and next-themes listens for them, so anything the automatic path persisted
+ * would retheme an already-open tab with no reload and no user action.
+ *
+ * Because only choices land here, "key absent" is an exact, self-describing
+ * test for "no human has chosen" — no companion marker key is needed to tell a
+ * seeded default apart from a real selection.
+ */
+export const THEME_CHOICE_STORAGE_KEY = "theme-choice";
 
 /**
- * Companion key holding the value the bootstrap script last auto-applied.
+ * Keys written by the previous seeding design, read once for migration.
  *
- * next-themes re-applies `defaultTheme` in a mount effect, so a script that
- * only sets the class is overwritten right after hydration. Seeding
- * `localStorage["theme"]` is therefore structurally required here — and this
- * marker is what keeps a required seed from freezing the default forever:
- * while `theme === theme-auto`, no human has actually chosen anything, so the
- * hour is re-resolved on every load. Any explicit selection clears the marker
- * and permanently ends the time rule.
+ * They are read and never removed. Removing `theme` would emit a `storage`
+ * event that a tab still running the old bundle would answer by writing its own
+ * default straight back — resurrecting the key without its marker, where it
+ * then reads as a permanent explicit choice. Leaving both in place is inert:
+ * nothing in the current design writes or watches either one.
  */
-export const THEME_AUTO_STORAGE_KEY = "theme-auto";
+export const LEGACY_THEME_STORAGE_KEY = "theme";
+export const LEGACY_THEME_AUTO_STORAGE_KEY = "theme-auto";
+
+/**
+ * Attribute the bootstrap stamps on `<html>` with the theme it auto-applied.
+ *
+ * This is how the resolved default reaches React without going through
+ * storage. `ThemeProvider` reads it during the client render and passes it as
+ * next-themes' `defaultTheme`, so next-themes' own mount effect re-applies the
+ * value already on screen instead of overwriting it.
+ *
+ * Absent means an explicit choice was in play, so nothing was auto-applied.
+ */
+export const AUTO_THEME_ATTRIBUTE = "data-theme-auto";
 
 export type TimeOfDayTheme = "light" | "dark";
 
@@ -39,11 +69,11 @@ export type TimeOfDayTheme = "light" | "dark";
  * Mobile browser-chrome colours, matching the `--background` tokens in
  * `globals.css` (`0 0% 100%` light, `240 10% 3.9%` dark).
  *
- * The static `viewport.themeColor` cannot track a theme resolved from the
- * client clock, so the bootstrap script keeps the `<meta name="theme-color">`
- * in sync. Without this the feature would introduce a mismatch it did not have
- * before: pre-change the page was always dark, so dark chrome matched; a light
- * 14:00 page under dark chrome is a regression this feature would have caused.
+ * The static `viewport.themeColor` cannot track a theme resolved on the client,
+ * so the bootstrap script keeps the `<meta name="theme-color">` in sync.
+ * Without this the feature would introduce a mismatch it did not have before:
+ * pre-change the page was always dark, so dark chrome matched; a light 14:00
+ * page under dark chrome is a regression this feature would have caused.
  */
 export const THEME_COLORS: Record<TimeOfDayTheme, string> = {
   light: "#ffffff",
@@ -66,53 +96,74 @@ export function resolveTimeOfDayTheme(hour: number): TimeOfDayTheme {
 }
 
 /**
- * Build the synchronous inline `<head>` script that applies the time-of-day
- * default before anything paints and before next-themes' own script runs.
+ * The full automatic default: a declared OS-dark preference outranks the hour,
+ * so the clock can only ever darken a light result, never lighten a dark one.
+ */
+export function resolveAutoTheme(
+  hour: number,
+  prefersDark: boolean,
+): TimeOfDayTheme {
+  return prefersDark ? "dark" : resolveTimeOfDayTheme(hour);
+}
+
+/**
+ * Build the synchronous inline script that settles the theme before anything
+ * paints.
+ *
+ * It must render **after** next-themes' own inline script, which applies
+ * `localStorage[storageKey] || defaultTheme` and would otherwise overwrite the
+ * automatic result with the server-serialised default. `ThemeProvider` owns
+ * that ordering by rendering this script as its first child; both are
+ * parser-blocking and no paintable markup precedes either.
  *
  * Precedence, evaluated once per document load:
  *
- * - `theme` absent            → resolve by hour, write both keys, apply.
- * - `theme === theme-auto`    → still an unmade choice → re-resolve by hour,
- *                               write both keys, apply.
- * - otherwise                 → a real explicit choice → touch neither storage
- *                               nor the class; next-themes owns both.
+ * - explicit `light` / `dark` → apply it; next-themes agrees on mount.
+ * - explicit `system`         → apply the OS preference, as next-themes will.
+ * - no choice                 → resolve from OS preference + hour, apply it,
+ *                               and stamp `data-theme-auto`. **No storage is
+ *                               written**, so no other tab is disturbed.
  *
  * In every branch the resolved colour is mirrored into
  * `<meta name="theme-color">`, which Next renders ahead of this script, so the
  * mobile chrome cannot disagree with the painted page.
  *
- * The whole body is exception-wrapped: if `localStorage` is unavailable or
- * throws, the script does nothing at all and the page falls through to
- * next-themes' pre-existing `defaultTheme` behaviour.
- *
- * `theme-auto` is written before `theme` on purpose. If the second write
- * fails (quota, denied storage) the surviving state is `theme` absent, which
- * simply re-resolves next load — the opposite order would leave a seeded
- * `theme` with no marker and freeze it as a fake explicit choice.
+ * Storage access is wrapped separately from the rest of the body: if
+ * `localStorage` is unavailable or throws, the automatic default still applies
+ * rather than the page falling through to next-themes' static default.
  */
 export function buildTimeOfDayThemeScript(): string {
   return [
     "(function(){try{",
-    `var K=${JSON.stringify(THEME_STORAGE_KEY)},A=${JSON.stringify(THEME_AUTO_STORAGE_KEY)};`,
+    `var C=${JSON.stringify(THEME_CHOICE_STORAGE_KEY)},L=${JSON.stringify(LEGACY_THEME_STORAGE_KEY)},M=${JSON.stringify(LEGACY_THEME_AUTO_STORAGE_KEY)};`,
+    `var ATTR=${JSON.stringify(AUTO_THEME_ATTRIBUTE)};`,
     `var DAY=${DAY_START_HOUR},NIGHT=${NIGHT_START_HOUR};`,
-    `var C=${JSON.stringify(THEME_COLORS)};`,
-    "var s=window.localStorage;",
-    "var raw=s.getItem(K),auto=s.getItem(A),t;",
-    "if(raw!==null&&raw!==auto){",
-    // An explicit choice: never touch storage or the class (next-themes owns
-    // both). Only mirror the resolved colour into the chrome meta.
-    "t=raw==='light'?'light':raw==='dark'?'dark':(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');",
-    "}else{",
+    `var COLORS=${JSON.stringify(THEME_COLORS)};`,
+    "var e=document.documentElement,s=null,c=null;",
+    "try{s=window.localStorage;}catch(err){}",
+    "if(s){",
+    "c=s.getItem(C);",
+    "if(c===null){",
+    // A legacy value that differs from the legacy marker was a real choice; a
+    // value equal to it was only ever a seeded default, so it stays unmigrated
+    // and this visitor simply returns to the automatic path.
+    "var lg=s.getItem(L);",
+    "if(lg!==null&&lg!==s.getItem(M)){s.setItem(C,lg);c=lg;}",
+    "}}",
+    "var d=!!(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);",
+    "var t;",
+    "if(c==='light'||c==='dark'){t=c;}",
+    "else if(c!==null){t=d?'dark':'light';}",
+    "else{",
     "var h=new Date().getHours();",
-    "t=(h>=NIGHT||h<DAY)?'dark':'light';",
-    "s.setItem(A,t);s.setItem(K,t);",
-    "var e=document.documentElement;",
+    "t=(d||h>=NIGHT||h<DAY)?'dark':'light';",
+    "e.setAttribute(ATTR,t);",
+    "}",
     "e.classList.remove('light','dark');",
     "e.classList.add(t);",
     "e.style.colorScheme=t;",
-    "}",
     "var m=document.querySelector('meta[name=\"theme-color\"]');",
-    "if(m&&C[t])m.setAttribute('content',C[t]);",
+    "if(m&&COLORS[t])m.setAttribute('content',COLORS[t]);",
     "}catch(err){}})();",
   ].join("");
 }


### PR DESCRIPTION
Fixes two defects in the client-timezone theme default. They ship together because fixing either alone makes the other worse.

## 1 · An open tab retheme itself with no reload and no user action

The automatic path wrote `localStorage` on every load. `storage` events fire in every **other** document of the origin, and next-themes registers a listener for them:

```js
o = r => r.key === m && (r.newValue ? n(r.newValue) : f(l))
```

So a tab opened at 07:05 re-resolved to `light`, wrote both keys, and a tab that had been open since 06:40 went light instantly, mid-read. `disableTransitionOnChange` makes it a hard cut rather than an ease — right for vestibular safety, more startling here. The harmful direction (dark → light at dawn) lands on exactly the light-sensitive cohort the feature exists to serve.

This is new behaviour introduced by the feature: before it, the no-choice path never wrote `theme`, so no default ever emitted a storage event.

## 2 · A declared OS-dark preference was overridden by the clock

`openharness-web` already states the rule this repo broke, in its own source:

> Forcing light at 14:00 on someone who set OS dark removes an accommodation they configured… the time rule may only ever upgrade light → dark, never dark → light.

OS is a *declared* preference — the only channel a platform gives a user to say "light surfaces hurt me". The hour is an *inferred* one. Converging costs nobody anything: an OS-dark user who wants light can still choose it, permanently.

## Why one PR

Shipping 2 alone **widens** 1. Post-fix, a second tab resolves differently the moment the OS theme changes — not only at the 07:00/18:00 boundary. That adds a brand-new trigger axis to a bug that already exists.

## The fix

Remove the seed. The bootstrap hands the resolved theme to React through a `data-theme-auto` attribute on `<html>`, and `ThemeProvider` passes it as next-themes' `defaultTheme` — which is the *only* thing the seed existed to satisfy (next-themes re-applies `defaultTheme` in a mount effect, so a script that just sets the class gets overwritten after hydration). Nothing is written, so nothing propagates.

Two obvious alternatives, both rejected:

| Alternative | Why it fails |
|---|---|
| Write only when the value differs | A no-op. Per the WHATWG Storage spec an unchanged `setItem` already fires no `storage` event; this suppresses only the writes that were already harmless. |
| Port the console's `forcedTheme` + adopt-DOM pattern | Silently strands "System". `forcedTheme` overrides all internal resolution *including* the system watcher, so the menu item would do nothing. |

### Storage key

next-themes' `storageKey` moves to `theme-choice`, holding explicit choices and nothing else — so "key absent" becomes an exact, self-describing test for "nobody has chosen", and the `theme-auto` marker is no longer needed.

Legacy keys are read once to migrate a genuine prior choice, and **deliberately never removed**. Removing `theme` would emit a `storage` event that a tab still running the old bundle answers by writing its own default straight back — resurrecting the key without its marker, where it then reads as a permanent explicit choice.

### Script placement

The bootstrap moves from `<head>` to `ThemeProvider`'s first child, so it runs immediately *after* next-themes' inline script instead of before it. Otherwise that script's **server-serialised** default overwrites the automatic result.

Verified against the built HTML — nothing paintable precedes the correction, so the no-flash guarantee is unchanged:

```
<body> @ 4207  →  script, script (JSON-LD)  →  next-themes @ 5834  →  correction @ 6063
tags between <body> and the correction: ['script', 'script', 'script']
```

## Verification

This repo has no test framework, so both layers were run against the **built** output rather than a re-read of the source.

**12/12 scenarios, executing the shipped script string against a fake DOM:**

| Scenario | Result |
|---|---|
| first visit · OS light · 14:00 | light · 0 storage writes |
| first visit · OS **dark** · 14:00 | **dark** · 0 writes |
| first visit · OS light · 21:00 / 03:00 | dark · 0 writes |
| boundaries 07:00 / 18:00 | light / dark · 0 writes |
| legacy auto seed (`theme === theme-auto`) | not migrated, back to auto · 0 writes |
| legacy explicit choice / no marker | migrated to `theme-choice`, honoured |
| explicit dark at 14:00 OS light | dark · 0 writes |
| explicit `system` · OS dark / OS light at 21:00 | dark / light — clock correctly ignored |

**Real browser (production build + `TZ` + emulated OS preference), read after hydration:**

| Run | class | `data-theme-auto` | `localStorage` |
|---|---|---|---|
| Denver 16:00 · OS light | `light` | `light` | **empty** |
| Denver 16:00 · OS **dark** | **`dark`** | `dark` | **empty** |
| UTC 22:00 · OS light | `dark` | `dark` | **empty** |
| choose Light at 22:00, reload | `light` | `null` | `{theme-choice: light}` |
| legacy auto seed, UTC 22:00 | `dark` | `dark` | legacy keys untouched |
| legacy explicit `{theme: light, theme-auto: dark}` | `light` | `null` | `theme-choice: light` added |

Empty storage on every automatic path is the mechanism proof for defect 1: no write, no `storage` event, no cross-tab flip.

Dev-mode run shows no Next.js error overlay, so the client-render `defaultTheme` read hydrates cleanly.

## Not in scope

- **Boundary behaviour is unchanged and deliberate.** Reloading across 07:00 changes the theme — the user initiated that load; that is the feature. No grace windows, no hysteresis.
- **No "System" option is added or removed.**
- The website still pins the inline script against nothing (no test framework). Worth its own ticket; three repos have now independently invented this "pre-paint script duplicates the tested rule as a string" pattern with three unequal safety nets.