### PR TITLE
fix: raise the CTA accent to AA on raised surfaces

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,6 +46,11 @@
     --oh-rule: #d8d2c2;
     --oh-control-border: #8a8375;
     --oh-accent: #15803d;
+    /* The accent, at the strength a raised surface needs. --oh-accent clears
+       4.5:1 on --oh-paper (4.53:1) but not on --oh-raised (4.02:1), and a
+       10% red alert overlay on that same surface drags it to 3.58:1. Darker
+       is the only lever that fixes both without restyling the surface. */
+    --oh-accent-raised: #166534;
     --oh-focus: #166534;
     --oh-solid: #22c55e;
     --oh-success-text: #166534;
@@ -92,6 +97,10 @@
     --oh-rule: #262626;
     --oh-control-border: #626262;
     --oh-accent: #4ade80;
+    /* Dark mode never had the problem — the accent already measures 11.36:1 on
+       --oh-raised and 10.51:1 through the alert overlay — so this deliberately
+       tracks --oh-accent rather than darkening anything. */
+    --oh-accent-raised: #4ade80;
     --oh-focus: #86efac;
     --oh-solid: #22c55e;
     --oh-success-text: #4ade80;

--- a/src/sections/CTASection.tsx
+++ b/src/sections/CTASection.tsx
@@ -111,7 +111,7 @@ export default function CTASection() {
           </ul>
 
           <aside className="mt-10 rounded-2xl border border-oh-rule bg-oh-raised p-5 sm:p-6">
-            <p className="font-mono text-xs font-semibold uppercase tracking-[0.18em] text-oh-accent">
+            <p className="font-mono text-xs font-semibold uppercase tracking-[0.18em] text-oh-accent-raised">
               What happens next
             </p>
             <p className="mt-3 font-montserrat text-sm leading-relaxed text-oh-ink sm:text-base">
@@ -155,7 +155,7 @@ export default function CTASection() {
               Something went wrong. Please try again, or email{" "}
               <a
                 href={`mailto:${OFFERING_URLS.supportEmail}`}
-                className="font-semibold underline underline-offset-4 hover:text-oh-accent"
+                className="font-semibold underline underline-offset-4 hover:text-oh-accent-raised"
               >
                 {OFFERING_URLS.supportEmail}
               </a>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -58,6 +58,7 @@ const config: Config = {
           muted: "var(--oh-muted)",
           rule: "var(--oh-rule)",
           accent: "var(--oh-accent)",
+          "accent-raised": "var(--oh-accent-raised)",
           focus: "var(--oh-focus)",
           solid: "var(--oh-solid)",
         },


### PR DESCRIPTION
Two WCAG 1.4.3 failures on the deployment CTA. Both are light-mode only.

| Location | Context | Now | Fixed |
|---|---|---|---|
| `CTASection.tsx:114` — "What happens next" eyebrow, 12px/600 | `#15803d` on `--oh-raised` `#eae6db` | **4.02:1** FAIL | 5.72:1 |
| `CTASection.tsx:158` — support-email hover, 14px/600 | `#15803d` on `bg-red-500/10` composited over `#eae6db` = `#ead6cc` | **3.58:1** FAIL | 5.09:1 |

Neither is large text (large = 18.66px bold or 24px), so the 4.5:1 threshold applies to both.

## `:158` is the worse one, in both senses

It **measures** lower, because the alert `div` composites a 10% red overlay onto the raised card rather than sitting on it directly. Measuring the flat token pair reports 4.02:1 and misses it — anyone verifying this must sample the composited colour.

And it matters more: it is the hover state of **the only recovery path from a failed form submission**. `:114`'s eyebrow is decorative framing whose meaning is carried by the paragraph directly beneath it.

It also illustrates a method gap worth naming — a scan of *rendered default state* structurally cannot see `hover:` colours or conditionally-rendered branches. Any contrast sweep that informs a ticket has to enumerate state-dependent colours from source.

## Why a new token, not a change to `--oh-accent`

`--oh-accent` stays `#15803d`. A new `--oh-accent-raised` carries the stronger value.

`text-oh-accent` has 55 usages and passes at 4.53:1 on `--oh-paper`, where the large majority of them live. `bg-oh-raised` appears exactly **3 times** repo-wide, and only **2** wrap accent-styled text.

Darkening the shared token would have been safe for *contrast* — `#166534` is strictly darker than `#15803d`, so ratios against any lighter background can only rise. The real risk is different: `--oh-accent` is visually paired with hardcoded, non-tokenised `green-500` in about six places (`RegisterButton.tsx`, `PricingSection.tsx`, `pricing/page.tsx`, `services/page.tsx`). A global swap darkens the text while those neighbours stay `#22c55e` — a brand-consistency regression, not an accessibility one.

## Dark mode is deliberately unchanged

`--oh-accent-raised` tracks `--oh-accent` exactly in dark. `#4ade80` already measures **11.36:1** on `--oh-raised` `#0a0a0a` and **10.51:1** through the alert overlay. Nothing to fix, so nothing changed.

## The third raised card

`OpenHarnessValueSection.tsx:67` puts `--oh-accent` on a 20px `aria-hidden` icon. Left alone: at 4.02:1 it clears the 3:1 non-text threshold in SC 1.4.11.

## Verification

Computed styles read from a real browser against the built site — not from source.

| Mode | Eyebrow | Its background | Hover link | Alert background |
|---|---|---|---|---|
| light | `rgb(22, 101, 52)` | `rgb(234, 230, 219)` | `rgb(22, 101, 52)` | `rgba(239, 68, 68, 0.1)` over `rgb(234, 230, 219)` |
| dark | `rgb(74, 222, 128)` | `rgb(10, 10, 10)` | `rgb(74, 222, 128)` | same overlay over `rgb(10, 10, 10)` |

The error state was reached by aborting the `/api/contact` request at the network layer, since that branch never renders otherwise.

## Not in scope

No change to `--oh-accent`, `--oh-focus`, `--oh-success-text`, or any `green-500` usage. This repo still has no contrast tooling in CI — worth its own ticket, given that the passing case nearby clears AA by only +0.026.