### PR TITLE
fix: report the active theme in the toggle menu

### DIFF
--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,21 +1,44 @@
 "use client";
 
+import * as React from "react";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+] as const;
 
 export function ModeToggle() {
   // Every selection here is an explicit choice, and `setTheme` is all it takes
   // to record one: the automatic default never writes storage, so the mere
   // presence of a stored value permanently ends the automatic path — including
   // when the user picks the same value the clock had already applied.
-  const { setTheme: chooseTheme } = useTheme();
+  const { theme, resolvedTheme, setTheme: chooseTheme } = useTheme();
+
+  // The active theme is not knowable during SSR, and on the client it is
+  // resolved from the DOM — so rendering it before mount would hydrate against
+  // markup the server could not have produced. Until then the control keeps its
+  // previous, state-free name.
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  const selected = THEME_OPTIONS.find((option) => option.value === theme);
+  const triggerLabel =
+    mounted && selected
+      ? selected.value === "system"
+        ? `Theme: System (currently ${resolvedTheme === "dark" ? "dark" : "light"})`
+        : `Theme: ${selected.label}`
+      : "Toggle theme";
 
   return (
     <DropdownMenu>
@@ -27,28 +50,29 @@ export function ModeToggle() {
         >
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
+          <span className="sr-only">{triggerLabel}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          className="min-h-11"
-          onClick={() => chooseTheme("light")}
+        {/*
+          A radio group rather than plain items: it is what gives each option
+          `role="menuitemradio"` and an `aria-checked` state, so the menu reports
+          which theme is active instead of only offering destinations.
+        */}
+        <DropdownMenuRadioGroup
+          value={mounted ? theme : undefined}
+          onValueChange={chooseTheme}
         >
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="min-h-11"
-          onClick={() => chooseTheme("dark")}
-        >
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="min-h-11"
-          onClick={() => chooseTheme("system")}
-        >
-          System
-        </DropdownMenuItem>
+          {THEME_OPTIONS.map((option) => (
+            <DropdownMenuRadioItem
+              key={option.value}
+              value={option.value}
+              className="min-h-11"
+            >
+              {option.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
> **Stacked on #54.** Base is `fix/theme-auto-os-dark-and-cross-tab` because both PRs touch `mode-toggle.tsx`. GitHub will retarget this to `development` automatically when #54 merges. Review that one first.

The theme menu offered three *destinations* and reported no *state*.

`DropdownMenuItem` carries `role="menuitem"` with no checked semantics, and the trigger's accessible name was the constant `"Toggle theme"`. So there was nowhere in the website UI that reported which theme is active. Sighted users read it off the page; screen-reader users had nothing.

Slightly ironic against the console, which already exposes `aria-pressed` and a literal "On"/"Off" in its authenticated menu.

## Fix

`DropdownMenuRadioGroup` / `DropdownMenuRadioItem` — both already exported by the design system (`ui/dropdown-menu.tsx:19,120`) and used nowhere. Each option now reports `role="menuitemradio"` with `aria-checked`, and gets the existing `ItemIndicator` dot for free.

The trigger names the current selection. "System" alone still doesn't tell you whether the page is light or dark *right now*, so that case resolves: `Theme: System (currently dark)`.

## This is pre-existing debt

`git show 2b66e7a -- mode-toggle.tsx` shows the time-of-day change only wrapped the `onClick` handlers. The plain-item structure predates it and was untouched. It ships here because it is the same control, not because that feature caused it.

## Hydration

The state-dependent name is gated behind a `mounted` flag. The active theme is unknowable during SSR and is resolved from the DOM on the client, so rendering it before mount would hydrate against markup the server could not have produced.

Verified against the built HTML: it contains `Toggle theme` and **zero** occurrences of `Theme: `.

## Verification

Accessibility properties read from a live browser, not from source.

| State | Trigger accessible name | Menu |
|---|---|---|
| automatic default, 16:00 local | `Theme: Light` | `menuitemradio` ×3 — `aria-checked` = `true` / `false` / `false` |
| after choosing System | `Theme: System (currently light)` | `theme-choice: system` persisted |
| System, OS flipped to dark | `Theme: System (currently dark)` | page follows — correct, the user asked for it |

## Note on the automatic default

Under the automatic default the menu shows Light or Dark checked, because that is genuinely the active theme. It does not claim the user chose it — nothing is persisted until they do.